### PR TITLE
rrweb console-record moved to a plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 "use strict";
 
 import * as rrweb from "rrweb";
+import { getRecordConsolePlugin } from '@rrweb/rrweb-plugin-console-record';
 import { v4 as uuidv4 } from "uuid";
 import config from "./config";
 
@@ -142,7 +143,7 @@ class Recorder {
     this.options = {
       ...config.recordOptions,
       emit: handleEvent,
-      plugins: [rrweb.getRecordConsolePlugin(config.recordConsolePlugin)],
+      plugins: [getRecordConsolePlugin(config.recordConsolePlugin)],
     };
     this.stop = null;
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bardrr",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -10,7 +10,8 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "rrweb": "^2.0.0-alpha.3",
+    "@rrweb/rrweb-plugin-console-record": "2.0.0-alpha.18",
+    "rrweb": "^2.0.0-alpha.18",
     "uuid": "^9.0.0"
   }
 }


### PR DESCRIPTION
getRecordConsolePlugin is no longer available as part of the base rrweb module.